### PR TITLE
uz80as expression parser fix for .db ~(1|2) != 0xfe

### DIFF
--- a/Source/HBIOS/Build.sh
+++ b/Source/HBIOS/Build.sh
@@ -5,6 +5,19 @@ set -e
 
 CPMCP=../../Tools/`uname`/cpmcp
 
+timestamp=$(date +%Y-%m-%d)
+#timestamp="2020-02-24"
+
+if [ $1 == '-d' ] ; then
+	shift
+	diffdir=$1
+	shift
+	if [ -f $diffdir/build.inc ] ; then
+		timestamp=$(grep TIMESTAMP $diffdir/build.inc | awk '{print $3}' | tr -d '\015"')	
+		echo diff build using $timestamp
+	fi	
+fi
+
 # positional arguments
 platform=$1
 config=$2
@@ -45,8 +58,6 @@ else
 fi
 
 Apps=(assign fdu format mode osldr rtc survey syscopy sysgen talk timer xm inttest)
-timestamp=$(date +%Y-%m-%d)
-#timestamp="2020-02-24"
 
 blankfile=Blank${romsize}KB.dat
 romdiskfile=RomDisk.tmp

--- a/Source/HBIOS/Makefile
+++ b/Source/HBIOS/Makefile
@@ -31,6 +31,11 @@ DEST = ../../Binary
 TOOLS =../../Tools
 OTHERS =  *.img *.rom *.com *.bin *.z80 cpm.sys zsys.sys Build.inc
 include $(TOOLS)/Makefile.inc
+
+ifeq ($(DIFFMAKE),1)
+	DIFFBUILD := -d $(DIFFTO)/Source/HBIOS
+endif
+
 DIFFPATH = $(DIFFTO)/Binary
 
 
@@ -39,7 +44,7 @@ ROMSIZE=512
 N8_std.rom: ROMSIZE=512
 
 %.rom:
-	bash Build.sh $(shell echo $* | tr '_' ' ') $(ROMSIZE)
+	bash Build.sh $(DIFFBUILD) $(shell echo $* | tr '_' ' ') $(ROMSIZE)
 
 #ZETA2_std.rom:
 #	bash Build.sh ZETA2 std 512

--- a/Tools/unix/uz80as/expr.c
+++ b/Tools/unix/uz80as/expr.c
@@ -156,7 +156,7 @@ static int ashr(int r, int n)
 const char *expr(const char *p, int *v, int linepc, int allowfr,
 	enum expr_ecode *ecode, const char **ep)
 {
-	int si, usi;
+	int si, usi, usl;
 	const char *q;
 	char last;
 	int stack[ESTKSZ2];
@@ -172,6 +172,7 @@ const char *expr(const char *p, int *v, int linepc, int allowfr,
 	si = 0;
 	r = 0;
 	last = 'V';	/* first void */
+	usl = 0;
 loop:
 	p = skipws(p);
 	if (*p == '(') {
@@ -184,6 +185,8 @@ loop:
 			}
 			stack[si++] = last;
 			stack[si++] = r;
+			stack[si++] = usl;
+			usl = usi;
 			p++;
 			r = 0;
 			last = 'v';	/* void */
@@ -197,6 +200,7 @@ loop:
 		} else {
 			p++;
 			n = r;
+			usl = stack[--si];
 			r = stack[--si];
 			last = (char) stack[--si];	
 			goto oper;
@@ -396,7 +400,7 @@ uoper:
 	uopstk[usi++] = *p++;
 	goto loop;
 oper:
-	while (usi > 0) {
+	while (usi > usl) {
 		usi--;
 		switch (uopstk[usi]) {
 		case '~': n = ~n; break;


### PR DESCRIPTION
I also added the ability to build with the same version number as extracted from a previous build that is pointed at for diffing.