### PR TITLE
Add github action for building RomWBW

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: rlespinasse/github-slug-action@1.1.0
+
+    - name: Install Dependencies
+      run: |
+        sudo apt-get install libncurses-dev
+    - name: Build
+      run: |
+        make
+        rm -rf .git
+    - name: Upload Archive
+      uses: actions/upload-artifact@v1
+      with:
+        name: RomWBW-${{env.GITHUB_REF_SLUG}}-${{env.GITHUB_SHA_SHORT}}
+        path: .


### PR DESCRIPTION
Builds RomWBW using the makefiles on an Ubuntu image. Runs on every pull, and attaches a zip of the build output to the run.

You can do more sophisticated things like doing a release when the repo is tagged... but this was just a start.

Cheers.