### PR TITLE
Make .gitignores for Tools/unix more specific

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,7 +55,21 @@ Source/ZPM3/gencpm.com
 Source/ZPM3/gencpm.dat
 
 Tools/Linux
-Tools/unix
+Tools/Darwin
+
+Tools/unix/bin2asm/bin2asm
+Tools/unix/cpmtools/cpmchattr
+Tools/unix/cpmtools/cpmchmod
+Tools/unix/cpmtools/cpmcp
+Tools/unix/cpmtools/cpmls
+Tools/unix/cpmtools/cpmrm
+Tools/unix/cpmtools/fsck.cpm
+Tools/unix/cpmtools/fsed.cpm
+Tools/unix/cpmtools/mkfs.cpm
+Tools/unix/lzsa/lzsa
+Tools/unix/uz80as/uz80as
+Tools/unix/zx/config.h
+Tools/unix/zx/zx
 
 !Source/Apps/FAT/FAT.COM
 !Source/BPBIOS/bpbuild.com


### PR DESCRIPTION
The new .gitignore blanket excluded the whole of the `Tools/unix` dir. This made it harder to add new files.

Have removed the global ignore and added specific files.

I contemplated creating individual .gitignore files in the specific tool directories, but have left it all in one for the time being.

Also added the macOS output dir.