### PR TITLE
Fix for building uz80as on GCC 10

### DIFF
--- a/Tools/unix/uz80as/Makefile
+++ b/Tools/unix/uz80as/Makefile
@@ -4,7 +4,7 @@
 
 DEST = ../../`uname`
 CC = gcc
-CFLAGS = -g
+CFLAGS = -g -fcommon
 
 OBJECTS = ngetopt.o main.o options.o \
 	utils.o err.o incl.o sym.o \


### PR DESCRIPTION
`-fno-common` is now the default in GCC 10. See C Language issues on https://gcc.gnu.org/gcc-10/porting_to.html

This results in errors when building uz80as:

```
gcc -g -o uz80as ngetopt.o main.o options.o utils.o err.o incl.o sym.o expr.o exprint.o pp.o list.o prtable.o uz80as.o targets.o z80.o gbcpu.o dp2200.o i4004.o i8008.o i8048.o i8051.o i8080.o mos6502.o mc6800.o 
/usr/bin/ld: prtable.o:/home/ed/dev/3rdparty/RomWBW/Tools/unix/uz80as/uz80as.h:11: multiple definition of `verbose'; main.o:/home/ed/dev/3rdparty/RomWBW/Tools/unix/uz80as/uz80as.h:11: first defined here
/usr/bin/ld: uz80as.o:/home/ed/dev/3rdparty/RomWBW/Tools/unix/uz80as/uz80as.h:11: multiple definition of `verbose'; main.o:/home/ed/dev/3rdparty/RomWBW/Tools/unix/uz80as/uz80as.h:11: first defined here
/usr/bin/ld: targets.o:/home/ed/dev/3rdparty/RomWBW/Tools/unix/uz80as/uz80as.h:11: multiple definition of `verbose'; main.o:/home/ed/dev/3rdparty/RomWBW/Tools/unix/uz80as/uz80as.h:11: first defined here
/usr/bin/ld: z80.o:/home/ed/dev/3rdparty/RomWBW/Tools/unix/uz80as/uz80as.h:11: multiple definition of `verbose'; main.o:/home/ed/dev/3rdparty/RomWBW/Tools/unix/uz80as/uz80as.h:11: first defined here
/usr/bin/ld: gbcpu.o:/home/ed/dev/3rdparty/RomWBW/Tools/unix/uz80as/uz80as.h:11: multiple definition of `verbose'; main.o:/home/ed/dev/3rdparty/RomWBW/Tools/unix/uz80as/uz80as.h:11: first defined here
/usr/bin/ld: dp2200.o:/home/ed/dev/3rdparty/RomWBW/Tools/unix/uz80as/uz80as.h:11: multiple definition of `verbose'; main.o:/home/ed/dev/3rdparty/RomWBW/Tools/unix/uz80as/uz80as.h:11: first defined here
/usr/bin/ld: i4004.o:/home/ed/dev/3rdparty/RomWBW/Tools/unix/uz80as/uz80as.h:11: multiple definition of `verbose'; main.o:/home/ed/dev/3rdparty/RomWBW/Tools/unix/uz80as/uz80as.h:11: first defined here
/usr/bin/ld: i8008.o:/home/ed/dev/3rdparty/RomWBW/Tools/unix/uz80as/uz80as.h:11: multiple definition of `verbose'; main.o:/home/ed/dev/3rdparty/RomWBW/Tools/unix/uz80as/uz80as.h:11: first defined here
/usr/bin/ld: i8048.o:/home/ed/dev/3rdparty/RomWBW/Tools/unix/uz80as/uz80as.h:11: multiple definition of `verbose'; main.o:/home/ed/dev/3rdparty/RomWBW/Tools/unix/uz80as/uz80as.h:11: first defined here
/usr/bin/ld: i8051.o:/home/ed/dev/3rdparty/RomWBW/Tools/unix/uz80as/uz80as.h:11: multiple definition of `verbose'; main.o:/home/ed/dev/3rdparty/RomWBW/Tools/unix/uz80as/uz80as.h:11: first defined here
/usr/bin/ld: i8080.o:/home/ed/dev/3rdparty/RomWBW/Tools/unix/uz80as/uz80as.h:11: multiple definition of `verbose'; main.o:/home/ed/dev/3rdparty/RomWBW/Tools/unix/uz80as/uz80as.h:11: first defined here
/usr/bin/ld: mos6502.o:/home/ed/dev/3rdparty/RomWBW/Tools/unix/uz80as/uz80as.h:11: multiple definition of `verbose'; main.o:/home/ed/dev/3rdparty/RomWBW/Tools/unix/uz80as/uz80as.h:11: first defined here
/usr/bin/ld: mc6800.o:/home/ed/dev/3rdparty/RomWBW/Tools/unix/uz80as/uz80as.h:11: multiple definition of `verbose'; main.o:/home/ed/dev/3rdparty/RomWBW/Tools/unix/uz80as/uz80as.h:11: first defined here
collect2: error: ld returned 1 exit status
make: *** [Makefile:59: uz80as] Error 1
```

Explicitly set -fcommon, the previous default, to fix this.