### PR TITLE
Additionally build on macos

### DIFF
--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -24,9 +24,43 @@ jobs:
           make
           make clean
           rm -rf .git*
-        
+      
+      - name: List Output
+        run: |
+          cd Binary
+          ls -l
+          find -type f -exec md5sum '{}' \;
+      
       - name: Upload Artifact
         uses: actions/upload-artifact@v1
         with:
           name: RomWBW-${{env.GITHUB_REF_SLUG}}-${{env.GITHUB_SHA_SHORT}}
+          path: .
+
+  buildMacos:
+    runs-on: macos-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Get OS info
+        run: |
+          system_profiler SPSoftwareDataType
+
+      - name: Build
+        run: |
+          make
+          make clean
+          rm -rf .git*
+
+      - name: List Output
+        run: |
+          cd Binary
+          ls -l
+          find . -type f -exec md5 -r -- '{}' +;
+        
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v1
+        with:
+          name: RomWBW-macOS
           path: .


### PR DESCRIPTION
Hi Wayne, hope you are well.

I saw in the Google group that people are having issues on macOS again and thought it might be useful to add a macOS build to the GitHub actions and see if that worked.

The macOS build does indeed fail on Github's runner - it fails to produce any ROM images with cpmcp erroring out:

```
 ../RomDsk/ROM_512KB/ASM.COM
cpmcp: can not create 00ASM.COM: directory full
make[2]: *** [DYNO_std.rom] Error 1
building in /Users/runner/work/RomWBW/RomWBW/Source/CPM3
cp optcmd.lib ldropts.lib	
../../Tools/Darwin/zx ../../Tools/cpm/bin/Z80ASM -BIOSLDR/MF
```

I added an md5sum listing + ls for the Binary folder for both builds so they could be compared.

Unfortunately I'm not sure what the resolution to the issue is at the moment, but thought this might help?

Ed
