### PR TITLE
Fix for multiple definition of 'verbose' in RomWBW/Tools/unix/uz80as/uz80as.h

### DIFF
--- a/Tools/unix/uz80as/uz80as.h
+++ b/Tools/unix/uz80as/uz80as.h
@@ -8,7 +8,7 @@
 #ifndef UZ80AS_H
 #define UZ80AS_H
 
-int verbose;
+static int verbose;
 
 /* matchtab.flags */
 enum {


### PR DESCRIPTION
Hi,

I tried compiling RomWBW on my Manjaro Linux distro PC. This Linux distro is using the most recent GCC version:

```
$ gcc --version
gcc (GCC) 10.2.0
```

And it gave quite a few **"multiple definition of `verbose'"** errors for the Tools/unix/uz80as/uz80as.h file, e.g.:

```
/usr/bin/ld: prtable.o:/home/koen/Documents/Projects/Retro/RomWBW/Tools/unix/uz80as/uz80as.h:11: multiple definition of `verbose'; 
main.o:/home/koen/Documents/Projects/Retro/RomWBW/Tools/unix/uz80as/uz80as.h:11: first defined here
```

This probably doesn't happen with older versions of GCC.

I was able to solve this quickly by adding "static" to the declaration of verbose. After this change, **make all** ran till the end without any problem for me.

