### PR TITLE
Update dma.asm

### DIFF
--- a/Source/HBIOS/dma.asm
+++ b/Source/HBIOS/dma.asm
@@ -72,7 +72,9 @@ DMA_INIT:
 	di
 	otir				; load dma
 	ei
+
 	xor	a			; set status
+	ld	(DMA_FAIL_FLAG),a	; ok to use dma
 ;
 DMA_EXIT:
 	DMAIOFULL
@@ -94,7 +96,7 @@ DMA_NOTFOUND:
 	jr	DMA_EXIT
 ;
 DMA_FAIL_FLAG:
-	.db	0	
+	.db	DMA_FAIL_FLAG	
 ;
 ;==================================================================================================
 ; DMA PROBE - WRITE TO ADDRESS REGISTER AND READ BACK


### PR DESCRIPTION
cp/m fails to boot with the dma driver included but no dma hardware installed. This is because the default "dma_fail_flag" indicates that the dma is good to go. But in safe mode the dma initialization never takes place to find no dma and set this flag, so the memory driver hangs. This change is to make the default status of the flag the failed state so the memory driver will fallback to software in recovery mode.