### PR TITLE
zxcc: Fix for load bios.bin failure on a RPi4

### DIFF
--- a/Tools/unix/zxcc/zxcc.c
+++ b/Tools/unix/zxcc/zxcc.c
@@ -127,7 +127,15 @@ void load_bios(void)
 		uint32_t size = CPM_MAXPATH - 8;
 		_NSGetExecutablePath(dir, &size);
 #else
-		readlink("/proc/self/exe", dir, CPM_MAXPATH - 8);   /* allow room for bios.bin */
+		ssize_t len;
+		len = readlink("/proc/self/exe", dir, CPM_MAXPATH - 8);   /* allow room for bios.bin */
+		if (len < 0)
+		{
+			/* len of -1 indicates an error occurred */
+			len = 0;
+		}
+		/* Terminate the dir string with a NUL character */
+		dir[len] = 0;
 #endif
 		q = strrchr(dir, DIRSEPCH);
 		*++q = 0;


### PR DESCRIPTION
This is a resolution for Issue #362

Fix load_bios() when used on a Raspberry Pi4.

The defect was corrupting the path of the zxcc executable.

The fix is to NUL terminate the path string from the readlink() call.