### PR TITLE
Publish the CPM2.2 CPM.SYS Binary Files in a new Binary/CPM22 folder

### DIFF
--- a/Binary/CPM22/Clean.cmd
+++ b/Binary/CPM22/Clean.cmd
@@ -1,0 +1,4 @@
+@echo off
+setlocal
+
+if exist *.sys del *.sys

--- a/Binary/CPM22/Makefile
+++ b/Binary/CPM22/Makefile
@@ -1,0 +1,7 @@
+TOOLS = ../../Tools
+MOREDIFF := $(shell $(TOOLS)/unix/casefn.sh *.spr)
+
+include $(TOOLS)/Makefile.inc
+
+clean::
+	@rm -f *.sys

--- a/Binary/CPM22/ReadMe.txt
+++ b/Binary/CPM22/ReadMe.txt
@@ -1,0 +1,23 @@
+***********************************************************************
+***                                                                 ***
+***                          R o m W B W                            ***
+***                                                                 ***
+***                    Z80/Z180 System Software                     ***
+***                                                                 ***
+***********************************************************************
+
+This directory contains the CP/M 2.2 system files for the RomWBW CP/M 2.2
+adaptation.  All of these files are already included on the CP/M
+boot disk images.  However if you are creating a CP/M boot disk
+manually, you should copy all of these files to the boot disk.
+
+Note: Two file have been provided one for RomWBW HBIOS, and one for UNA
+BIOS. One of these files must be installed on the system boot track.
+This is usually achieved by the SYSCOPY utility e.g.
+
+SYSCOPY a:=cpm_wbw.sys
+
+These files should also be copied to any CP/M 2.2 boot disks on your
+system when you upgrade your ROM firmware.  Some of these files
+*must* match the version of the RomWBW firmware you are using for
+proper operation of your system.

--- a/Binary/Clean.cmd
+++ b/Binary/Clean.cmd
@@ -14,5 +14,6 @@ if exist *.eeprom del *.eeprom
 pushd Apps && call Clean || exit /b 1 & popd
 pushd CPM22 && call Clean || exit /b 1 & popd
 pushd CPM3 && call Clean || exit /b 1 & popd
+pushd ZSDOS && call Clean || exit /b 1 & popd
 pushd ZPM3 && call Clean || exit /b 1 & popd
 pushd CPNET && call Clean || exit /b 1 & popd

--- a/Binary/Clean.cmd
+++ b/Binary/Clean.cmd
@@ -12,6 +12,7 @@ if exist *.pdf del *.pdf
 if exist *.eeprom del *.eeprom
 
 pushd Apps && call Clean || exit /b 1 & popd
+pushd CPM22 && call Clean || exit /b 1 & popd
 pushd CPM3 && call Clean || exit /b 1 & popd
 pushd ZPM3 && call Clean || exit /b 1 & popd
 pushd CPNET && call Clean || exit /b 1 & popd

--- a/Binary/Clean.cmd
+++ b/Binary/Clean.cmd
@@ -14,6 +14,7 @@ if exist *.eeprom del *.eeprom
 pushd Apps && call Clean || exit /b 1 & popd
 pushd CPM22 && call Clean || exit /b 1 & popd
 pushd CPM3 && call Clean || exit /b 1 & popd
+pushd QPM && call Clean || exit /b 1 & popd
 pushd ZSDOS && call Clean || exit /b 1 & popd
 pushd ZPM3 && call Clean || exit /b 1 & popd
 pushd CPNET && call Clean || exit /b 1 & popd

--- a/Binary/Makefile
+++ b/Binary/Makefile
@@ -1,6 +1,6 @@
 TOOLS = ../Tools
 MOREDIFF := $(shell $(TOOLS)/unix/casefn.sh *.img *.rom *.com *.eeprom)
-SUBDIRS = Apps CPM22 CPM3 ZSDOS ZPM3 CPNET
+SUBDIRS = Apps CPM22 CPM3 QPM ZSDOS ZPM3 CPNET
 
 include $(TOOLS)/Makefile.inc
 

--- a/Binary/Makefile
+++ b/Binary/Makefile
@@ -1,6 +1,6 @@
 TOOLS = ../Tools
 MOREDIFF := $(shell $(TOOLS)/unix/casefn.sh *.img *.rom *.com *.eeprom)
-SUBDIRS = Apps CPM3 ZPM3 CPNET
+SUBDIRS = Apps CPM22 CPM3 ZPM3 CPNET
 
 include $(TOOLS)/Makefile.inc
 

--- a/Binary/Makefile
+++ b/Binary/Makefile
@@ -1,6 +1,6 @@
 TOOLS = ../Tools
 MOREDIFF := $(shell $(TOOLS)/unix/casefn.sh *.img *.rom *.com *.eeprom)
-SUBDIRS = Apps CPM22 CPM3 ZPM3 CPNET
+SUBDIRS = Apps CPM22 CPM3 ZSDOS ZPM3 CPNET
 
 include $(TOOLS)/Makefile.inc
 

--- a/Binary/QPM/Clean.cmd
+++ b/Binary/QPM/Clean.cmd
@@ -1,0 +1,4 @@
+@echo off
+setlocal
+
+if exist *.sys del *.sys

--- a/Binary/QPM/Makefile
+++ b/Binary/QPM/Makefile
@@ -1,0 +1,7 @@
+TOOLS = ../../Tools
+MOREDIFF := $(shell $(TOOLS)/unix/casefn.sh *.spr)
+
+include $(TOOLS)/Makefile.inc
+
+clean::
+	@rm -f *.sys *.bin

--- a/Binary/QPM/ReadMe.txt
+++ b/Binary/QPM/ReadMe.txt
@@ -1,0 +1,21 @@
+***********************************************************************
+***                                                                 ***
+***                          R o m W B W                            ***
+***                                                                 ***
+***                    Z80/Z180 System Software                     ***
+***                                                                 ***
+***********************************************************************
+
+This directory contains the QPM 2.7 system files for the RomWBW QPM 2.7
+adaptation.  All of these files are already included on the QPM
+boot disk images.  However if you are creating a QPM boot disk
+manually, you should copy all of these files to the boot disk.
+
+Note: Two file have been provided one for RomWBW HBIOS, and one for UNA
+BIOS. One of these files must be installed on the system boot track.
+Refer to the QPM Documentation for installing QPM
+
+These files should also be copied to any QPM boot disks on your
+system when you upgrade your ROM firmware.  Some of these files
+*must* match the version of the RomWBW firmware you are using for
+proper operation of your system.

--- a/Binary/ReadMe.txt
+++ b/Binary/ReadMe.txt
@@ -180,8 +180,8 @@ This directory contains the CP/NET client packages.  Please refer to
 the RomWBW User Guide for instructions on installing these packages,
 or see the Readme.txt file in this sub-directory
 
-CPM22 CPM3 ZSDOS ZPM3 Directories
----------------------------------
+CPM22 CPM3 ZSDOS ZPM3 QPM Directories
+-------------------------------------
 
 These directories contains the system files for the RomWBW adaptations
 for each operating system.  All of these files are already included on

--- a/Binary/ReadMe.txt
+++ b/Binary/ReadMe.txt
@@ -163,9 +163,32 @@ indicates which file targets each of the Propeller board variants:
 Refer to the board documentation of the boards for more information
 on how to program the EEPROMs on these boards.
 
+SUB DIRECTORIES
+===============
+
 Apps Directory
 --------------
 
 The Apps subdirectory contains the executable application files that
 are specific to RomWBW.  The source for these applications is found
 in the Source\Apps directory of the distribution.
+
+CPNET Directory
+---------------
+
+This directory contains the CP/NET client packages.  Please refer to
+the RomWBW User Guide for instructions on installing these packages,
+or see the Readme.txt file in this sub-directory
+
+CPM22 CPM3 ZPM3 Directories
+---------------------------
+
+These directories contains the system files for the RomWBW adaptations
+for each operating system.  All of these files are already included on
+the boot disk images.  However if you are creating a o/s boot disk
+manually, you will need copy all of these files to the boot disk.
+
+These files should also be copied to any boot disks on your
+system when you upgrade your ROM firmware.  Some of these files
+*must* match the version of the RomWBW firmware you are using for
+proper operation of your system.

--- a/Binary/ReadMe.txt
+++ b/Binary/ReadMe.txt
@@ -180,8 +180,8 @@ This directory contains the CP/NET client packages.  Please refer to
 the RomWBW User Guide for instructions on installing these packages,
 or see the Readme.txt file in this sub-directory
 
-CPM22 CPM3 ZPM3 Directories
----------------------------
+CPM22 CPM3 ZSDOS ZPM3 Directories
+---------------------------------
 
 These directories contains the system files for the RomWBW adaptations
 for each operating system.  All of these files are already included on

--- a/Binary/ZSDOS/Clean.cmd
+++ b/Binary/ZSDOS/Clean.cmd
@@ -1,0 +1,4 @@
+@echo off
+setlocal
+
+if exist *.sys del *.sys

--- a/Binary/ZSDOS/Makefile
+++ b/Binary/ZSDOS/Makefile
@@ -1,0 +1,7 @@
+TOOLS = ../../Tools
+MOREDIFF := $(shell $(TOOLS)/unix/casefn.sh *.spr)
+
+include $(TOOLS)/Makefile.inc
+
+clean::
+	@rm -f *.sys

--- a/Binary/ZSDOS/ReadMe.txt
+++ b/Binary/ZSDOS/ReadMe.txt
@@ -1,0 +1,23 @@
+***********************************************************************
+***                                                                 ***
+***                          R o m W B W                            ***
+***                                                                 ***
+***                    Z80/Z180 System Software                     ***
+***                                                                 ***
+***********************************************************************
+
+This directory contains the ZSDOS system files for the RomWBW ZSDOS
+adaptation.  All of these files are already included on the ZSDOS
+boot disk images.  However if you are creating a ZSDOS boot disk
+manually, you should copy all of these files to the boot disk.
+
+Note: Two file have been provided one for RomWBW HBIOS, and one for UNA
+BIOS. One of these files must be installed on the system boot track.
+This is usually achieved by the SYSCOPY utility e.g.
+
+SYSCOPY a:=zsys_wbw.sys
+
+These files should also be copied to any ZSDOS boot disks on your
+system when you upgrade your ROM firmware.  Some of these files
+*must* match the version of the RomWBW firmware you are using for
+proper operation of your system.

--- a/Source/CPM22/Build.cmd
+++ b/Source/CPM22/Build.cmd
@@ -38,6 +38,10 @@ copy /b os2ccp.bin + os3bdos.bin + ..\cbios\cbios_una.bin cpm_una.bin || exit /b
 copy /b loader.bin + cpm_wbw.bin cpm_wbw.sys || exit /b
 copy /b loader.bin + cpm_una.bin cpm_una.sys || exit /b
 
+rem Copy OS files to Binary directory
+copy cpm_wbw.sys ..\..\Binary\CPM22 || exit /b
+copy cpm_una.sys ..\..\Binary\CPM22 || exit /b
+
 goto :eof
 
 :asm

--- a/Source/CPM22/Makefile
+++ b/Source/CPM22/Makefile
@@ -3,7 +3,13 @@ BINFILES = cpm_wbw.bin cpm_una.bin
 OBJECTS = CCP.bin BDOS.bin CCP22.bin BDOS22.bin OS2CCP.bin OS3BDOS.bin \
 	ccpb03.bin bdosb01.bin loader.bin $(SYSFILES) $(BINFILES)
 OTHERS = *.hex
+NOCOPY = cpm_wbw.bin cpm_una.bin \
+	CCP.bin BDOS.bin CCP22.bin BDOS22.bin OS2CCP.bin OS3BDOS.bin \
+	ccpb03.bin bdosb01.bin loader.bin
+
+DEST = ../../Binary/CPM22
 TOOLS = ../../Tools
+
 include $(TOOLS)/Makefile.inc
 
 %.sys: %.bin loader.bin

--- a/Source/QPM/Build.cmd
+++ b/Source/QPM/Build.cmd
@@ -17,4 +17,8 @@ copy /b qcp27.dat + qdos27.dat + ..\cbios\cbios_una.bin qpm_una.bin || exit /b
 copy /b loader.bin + qpm_wbw.bin qpm_wbw.sys || exit /b
 copy /b loader.bin + qpm_una.bin qpm_una.sys || exit /b
 
+rem Copy OS files to Binary directory
+copy qpm_wbw.sys ..\..\Binary\QPM || exit /b
+copy qpm_una.sys ..\..\Binary\QPM || exit /b
+
 goto :eof

--- a/Source/QPM/Makefile
+++ b/Source/QPM/Makefile
@@ -2,6 +2,8 @@ SYSFILES = qpm_wbw.sys qpm_una.sys
 BINFILES = qpm_wbw.bin qpm_una.bin
 OBJECTS = loader.bin $(SYSFILES) $(BINFILES)
 OTHERS = *.hex
+NOCOPY = qpm_wbw.bin qpm_una.bin loader.bin loader.lst
+DEST = ../../Binary/QPM
 TOOLS = ../../Tools
 include $(TOOLS)/Makefile.inc
 

--- a/Source/ZSDOS/Build.cmd
+++ b/Source/ZSDOS/Build.cmd
@@ -19,3 +19,7 @@ copy /b ..\zcpr-dj\zcpr.bin + zsdos.bin + ..\cbios\cbios_una.bin zsys_una.bin ||
 
 copy /b loader.bin + zsys_wbw.bin zsys_wbw.sys || exit /b
 copy /b loader.bin + zsys_una.bin zsys_una.sys || exit /b
+
+rem Copy OS files to Binary directory
+copy zsys_wbw.sys ..\..\Binary\ZSDOS || exit /b
+copy zsys_una.sys ..\..\Binary\ZSDOS || exit /b

--- a/Source/ZSDOS/Makefile
+++ b/Source/ZSDOS/Makefile
@@ -2,6 +2,8 @@ SYSFILES = zsys_wbw.sys zsys_una.sys
 BINFILES =  zsys_wbw.bin zsys_una.bin
 OBJECTS = $(SYSFILES) $(BINFILES)
 OTHERS = zsdos.rel zsdos.err loader.bin zsdos.bin
+NOCOPY = zsys_wbw.bin zsys_una.bin loader.* zsdos.*
+DEST = ../../Binary/ZSDOS
 TOOLS = ../../Tools
 CCP = ../ZCPR-DJ/zcpr.bin
 


### PR DESCRIPTION
Publish the CPM2.2 CPM.SYS Binary Files in a new Binary/CPM22 folder

Motivation.
a) Consistent with other OS (e.g. CPM3) publishing binary files to /Binary
b) During an upgrade will need these to update CPM22 boot drives. Currently only in Source folders

Testing: I have tested with Make, but don't have Win environment to test CMD files