### PR TITLE
Rom Bank Layout improvements

### DIFF
--- a/Source/HBIOS/Layout.txt
+++ b/Source/HBIOS/Layout.txt
@@ -5,34 +5,49 @@ Final Output Files
 ROM Output File [512K] -> <config>.rom
   hbios_rom [32K]
   OSIMG  [32K]
-  OSIMG1 [32K] 
-  OSIMG  [32K] (used as filler)
+  OSIMG1 [32K]
+  OSIMG2 [32K]
   romdisk - [384K]
 
-COM Output File -> <config>.com
-  hbios_com [varies]
-  OSIMG [32K]
+UPD Output File [128K] -> <config>.upd
+  hbios_rom [32K]
+  OSIMG  [32K]
+  OSIMG1 [32K]
+  OSIMG2 [32K]
 
-IMG Output File -> <config>.img
-  hbios_img [varies]
-  OSIMG [32K]
+COM Output File -> <config>.com
+  hbios_app [varies]
+  OSIMG_SMALL [32K]
 
 -------------------------
 Intermediate Output Files
 -------------------------
 
 OSIMG [32K] -> osimg.bin
-  romldr [3.5K]
-  eastaegg [0.5K]
-  dbgmon [4K]		
+  romldr [4K]
+  dbgmon [4K]
+  ZSYS (zcpr/zsdos/cbios) [12K]
   CPM (ccp/bdos/cbios) [12K]
+
+OSIMG_SMALL [20K] -> osimg_small.bin
+  romldr [4K]
+  dbgmon [4K]
   ZSYS (zcpr/zsdos/cbios) [12K]
 
-OSIMG1 [32K] -> osimg0.bin
-  camel80 [5.75K]
-  nascom [8K]
-  tastybasic [2.25K]
-  imagepad0 [-]
+OSIMG1 [32K] -> osimg1.bin
+  camel80     [5.75K]
+  nascom      [8K]
+  tastybasic  [2.5K]
+  game        [2.25K]
+  eastaegg    [0.5K]
+  netboot     [4K]
+  updater.bin [3.25K]
+  sysconf.bin [2K]
+  usrrom.bin  [3.75K (padded)]
+
+OSIMG2 [32K] -> osimg2.bin
+  s100mon     [8.25kb (optional)]
+  (OR) not populated
 
 CPM [12K] -> cpm.bin
   ccp [2K]
@@ -48,7 +63,7 @@ ZSYS [12K] -> zsys.bin
 Compilation Units
 -----------------
 
-hbios.asm -> hbios_rom.bin, hbios_app.bin, hbios_img.bin
+hbios.asm -> hbios_rom.bin, hbios_app.bin
   std.asm
     ver.inc
     hbios.inc
@@ -92,7 +107,7 @@ eastaegg.asm -> eastaegg.bin
 
 Forth\camel80.azm -> Forth\camel80.bin -> ..\camel80.bin
   camel80d.azm
-  camel80h.azm	
+  camel80h.azm
 
 nascom.asm -> nascom.bin
   std.asm
@@ -109,8 +124,8 @@ tastybasic.asm -> tastybasic.bin
     build.inc
       <config>.asm
     plt_<platform>.inc
- 
-  
+
+
 =======================================================================
 HBIOS Loading Modes:
   ROMBOOT: Startup from ROM Bank BID_BOOT

--- a/Source/HBIOS/layout.inc
+++ b/Source/HBIOS/layout.inc
@@ -32,11 +32,17 @@ CPM_ENT		.EQU	CBIOS_LOC		; CPM ENTRY POINT (IN CBIOS)
 ;
 CPM_IMGSIZ	.EQU	$3000
 ;
-; =================
-; ROM BANK 1 LAYOUT
-; =================
+; =============================
+; ROM BANK 0    (hbios_rom.bin)
+; =============================
 ;
-LDR_LOC		.EQU	$0000
+; See hbios.asm for content of Bank 0
+;
+; =============================
+; ROM BANK 1 LAYOUT (osimg.bin)
+; =============================
+;
+LDR_LOC		.EQU	$0000			; ROM LOADER
 LDR_SIZ		.EQU	$1000
 LDR_END		.EQU	LDR_LOC +LDR_SIZ
 LDR_IMGLOC	.EQU	$0000
@@ -46,13 +52,16 @@ MON_SIZ		.EQU	$1000			; SIZE OF MONITOR BINARY IMAGE
 MON_END		.EQU	MON_LOC + MON_SIZ	; END OF MONITOR
 MON_IMGLOC	.EQU	LDR_IMGLOC + LDR_SIZ
 ;
-ZSYS_IMGLOC	.EQU	MON_IMGLOC + MON_SIZ
+ZSYS_IMGLOC	.EQU	MON_IMGLOC + MON_SIZ	; ZSDOS / Z-System
 ;
-CPM_IMGLOC	.EQU	ZSYS_IMGLOC + CPM_IMGSIZ
+CPM_IMGLOC	.EQU	ZSYS_IMGLOC + CPM_IMGSIZ ; CP/M 2.2
 ;
-; =================
-; ROM BANK 2 LAYOUT
-; =================
+BNK1_IMGEND	.EQU	CPM_IMGLOC + CPM_IMGSIZ	; END OF BANK
+BNK1_REMAIN	.EQU	BNKTOP - BNK1_IMGEND	; REMAINING
+;
+; ==============================
+; ROM BANK 2 LAYOUT (osimg1.bin)
+; ==============================
 ;
 FTH_LOC		.EQU	$0200			; CAMEL FORTH
 FTH_SIZ		.EQU	$1700
@@ -96,6 +105,41 @@ NVR_END		.EQU	NVR_LOC + NVR_SIZ
 NVR_IMGLOC	.EQU	UPD_IMGLOC + UPD_SIZ
 ;
 USR_LOC		.EQU	$0200			; USER
-USR_SIZ		.EQU	BNKTOP - NVR_IMGLOC - NVR_SIZ
+USR_SIZ		.EQU	$0200
 USR_END		.EQU	USR_LOC + USR_SIZ
 USR_IMGLOC	.EQU	NVR_IMGLOC + NVR_SIZ
+;
+BNK2_IMGEND	.EQU	USR_IMGLOC + USR_SIZ	; END OF BANK
+BNK2_REMAIN	.EQU	BNKTOP - BNK2_IMGEND	; REMAINING
+;
+; ==============================
+; ROM BANK 3 LAYOUT (osimg2.bin)
+; ==============================
+;
+; not defined here, see build files
+; optionally contains S100 monitor
+;
+; =================
+;
+#IFDEF BNKINFO
+	.ECHO "-------------------------------\n"
+	.ECHO "ROM BANK INFO  \tLENGTH \tREMAIN \n"
+	.ECHO "---------------\t-------\t-------\n"
+	.ECHO "BANK1 BID_IMG0 \t" \ .ECHO BNK1_IMGEND \ .ECHO "\t" \ .ECHO BNK1_REMAIN \ .ECHO "\n"
+	.ECHO "BANK2 BID_IMG1 \t" \ .ECHO BNK2_IMGEND \ .ECHO "\t" \ .ECHO BNK2_REMAIN \ .ECHO "\n"
+	.ECHO "-------------------------------\n"
+;
+  #IF (BNK1_IMGEND > BNKTOP)
+	.ECHO	"*** BANK 1 IS TOO BIG!!!\n"
+	!!!	; FORCE AN ASSEMBLY ERROR IF BANK SIZE EXCEEDS SPACE
+  #ENDIF
+  #IF (BNK2_IMGEND > BNKTOP)
+	.ECHO	"*** BANK 2 IS TOO BIG!!!\n"
+	!!!	; FORCE AN ASSEMBLY ERROR IF BANK SIZE EXCEEDS SPACE
+  #ENDIF
+;
+#ENDIF
+
+
+
+

--- a/Source/HBIOS/usrrom.asm
+++ b/Source/HBIOS/usrrom.asm
@@ -191,11 +191,6 @@ MESSAGE:
 ;
 SLACK	.EQU	(USR_END - $)
 ;
-#IF (SLACK < 0)
-	.ECHO	"*** USRAPP IS TOO BIG!!!\n"
-	!!!	; FORCE AN ASSEMBLY ERROR
-#ENDIF
-;
 	.FILL	SLACK,$00
 	.ECHO	"User ROM space remaining: "
 	.ECHO	SLACK


### PR DESCRIPTION
Issues
* Rom Bank 1 has no size constraint, can increase romldr (oversize) without build issue, bank truncation 
* Rom bank 2 usrrom (last app) has size constraint check, shouldn't be function of app 
* Rom bank 2 usr rom pads to end of 32k in its Size, unnecessary as handled by "srec_cat -crop"

So
* move out the bank size protections (from usrrom) into layout.inc
* ensure bank 1 has same protection as bank2.
* make user rom a realistic size ($200), padding handled by CRC check
* also good to .ECHO overall sizes of banks, improve logging.
* updated documentation in layout.txt

Addressed Issue #489 
