### PR TITLE
Add flow to generate documentation page via MkDocs and GitHub Pages

### DIFF
--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -25,15 +25,25 @@ jobs:
       - name: Build
         run: |
           export TZ='America/Los_Angeles'
-          sudo apt-get install srecord
+          sudo apt-get install srecord gpp pandoc
+          pip install mkdocs
           make distlog
           rm -rf .git*
+          make -C Source/Doc deploy_mkdocs
+          mkdocs build -f Source/Doc/mkdocs.yml
 
       - name: List Output
         run: |
           cd Binary
           ls -l
           find -type f -exec md5sum '{}' \;
+
+      - name: Deploy Docs
+        uses: peaceiris/actions-gh-pages@v4
+        if: github.ref == 'refs/heads/master'
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: Source/Doc/site
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v4.3.0

--- a/Source/Doc/Makefile
+++ b/Source/Doc/Makefile
@@ -31,12 +31,12 @@ all :: deploy
 	pandoc $< -f markdown -t dokuwiki -s -o $@ --default-image-extension=pdf
 
 %.gfm : %.tmp
-	pandoc $< -f markdown -t gfm-yaml_metadata_block -s -o $@ --default-image-extension=pdf
+	pandoc $< -f markdown -t gfm-yaml_metadata_block -s -o $@ --default-image-extension=svg
 
 %.txt : %.tmp
 	pandoc $< -f markdown -t plain -s -o $@ --default-image-extension=pdf
 
-deploy :
+deploy : deploy_mkdocs
 	cp Introduction.gfm      "../../ReadMe.md"
 	cp Introduction.txt      "../../ReadMe.txt"
 	cp Introduction.pdf      "../../Doc/RomWBW Introduction.pdf"
@@ -45,3 +45,16 @@ deploy :
 	cp Applications.pdf      "../../Doc/RomWBW Applications.pdf"
 	cp Catalog.pdf           "../../Doc/RomWBW Disk Catalog.pdf"
 	cp Hardware.pdf          "../../Doc/RomWBW Hardware.pdf"
+
+deploy_mkdocs : Introduction.gfm UserGuide.gfm SystemGuide.gfm Applications.gfm Catalog.gfm Hardware.gfm
+	rm -rf mkdocs
+	mkdir -p mkdocs/UserGuide/Graphics mkdocs/SystemGuide/Graphics
+	cp Introduction.gfm      mkdocs/Introduction.md
+	cp UserGuide.gfm         mkdocs/UserGuide.md
+	cp SystemGuide.gfm       mkdocs/SystemGuide.md
+	cp Applications.gfm      mkdocs/Applications.md
+	cp Catalog.gfm           mkdocs/Catalog.md
+	cp Hardware.gfm          mkdocs/Hardware.md
+	cp ReadMe.md             mkdocs/README.md
+	cp Graphics/*.svg        mkdocs/UserGuide/Graphics
+	cp Graphics/*.svg        mkdocs/SystemGuide/Graphics

--- a/Source/Doc/mkdocs.yml
+++ b/Source/Doc/mkdocs.yml
@@ -1,0 +1,16 @@
+site_name: RomWBW Documentation V3.6
+repo_url: https://github.com/wwarthen/RomWBW
+edit_uri: ""
+docs_dir: mkdocs
+nav:
+  - Introduction: Introduction.md
+  - User Guide: UserGuide.md
+  - System Guide: SystemGuide.md
+  - Applications: Applications.md
+  - Catalog: Catalog.md
+  - Hardware: Hardware.md
+theme:
+  name: mkdocs
+  color_mode: auto
+  user_color_mode_toggle: true
+  navigation_depth: 3


### PR DESCRIPTION
As discussed in #553, this pull request adds a flow for generating a nice looking online RomWBW documentation site. The Makefile Source/Doc is modified to generate the input files into MkDocs from the  GitHub Flavored Markdown (GFM) files generated by the pandoc based PDF flow. Steps are added to the existing GitHub commit Action to build the docs and commit the generated documentation site to the `gh-pages` branch of the repository. 

After the first time this flow is successfully run (once the PR is accepted), Wayne you will need to go to the 'Pages' section of this repository's setting page to enable display of the docs.  See [here](https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site) for how to do that, where the branch is `gh-pages`. A few minutes later, https://wwarthen.github.io/RomWBW should be live.