### PR TITLE
Fix links in online docs to not link to PDF files.

### DIFF
--- a/Source/Doc/Basic.h
+++ b/Source/Doc/Basic.h
@@ -14,7 +14,14 @@ $define{doc_sys}{[RomWBW System Guide]($doc_root$/RomWBW System Guide.pdf)}$
 $define{doc_apps}{[RomWBW Applications]($doc_root$/RomWBW Applications.pdf)}$
 $define{doc_catalog}{[RomWBW Disk Catalog]($doc_root$/RomWBW Disk Catalog.pdf)}$
 $define{doc_hardware}{[RomWBW Hardware]($doc_root$/RomWBW Hardware.pdf)}$
-
+$ifdef{GFM}$
+  $define{doc_intro}{[RomWBW Introduction](Introduction.md)}$
+  $define{doc_user}{[RomWBW User Guide](UserGuide.md)}$
+  $define{doc_sys}{[RomWBW System Guide](SystemGuide.md)}$
+  $define{doc_apps}{[RomWBW Applications](Applications.md)}$
+  $define{doc_catalog}{[RomWBW Disk Catalog](Catalog.md)}$
+  $define{doc_hardware}{[RomWBW Hardware](Hardware.md)}$
+$endif$
 ---
 title: $doc_product$ $doc_title$
 subtitle: $doc_ver$

--- a/Source/Doc/Makefile
+++ b/Source/Doc/Makefile
@@ -18,10 +18,6 @@ include $(TOOLS)/Makefile.inc
 
 all :: deploy
 
-clean ::
-	rm -rf mkdocs
-	rm -rf site
-
 %.tmp : %.md
 	gpp -o $@ -U "$$" "$$" "{" "}{" "}$$" "{" "}" "@@@" "" -M "$$" "$$" "{" "}{" "}$$" "{" "}" $<
 
@@ -40,7 +36,12 @@ clean ::
 %.txt : %.tmp
 	pandoc $< -f markdown -t plain -s -o $@ --default-image-extension=pdf
 
-deploy :
+mkdocs/%.md : %.md
+	-mkdir -p mkdocs
+	gpp -DGFM -U "$$" "$$" "{" "}{" "}$$" "{" "}" "@@@" "" -M "$$" "$$" "{" "}{" "}$$" "{" "}" $< \
+	    | pandoc -f markdown -t gfm-yaml_metadata_block -s -o $@ --default-image-extension=svg
+
+deploy : deploy_mkdocs
 	cp Introduction.gfm      "../../ReadMe.md"
 	cp Introduction.txt      "../../ReadMe.txt"
 	cp Introduction.pdf      "../../Doc/RomWBW Introduction.pdf"
@@ -50,15 +51,9 @@ deploy :
 	cp Catalog.pdf           "../../Doc/RomWBW Disk Catalog.pdf"
 	cp Hardware.pdf          "../../Doc/RomWBW Hardware.pdf"
 
-deploy_mkdocs : Introduction.gfm UserGuide.gfm SystemGuide.gfm Applications.gfm Catalog.gfm Hardware.gfm ReadMe.gfm
-	rm -rf mkdocs
+deploy_mkdocs : mkdocs/Introduction.md mkdocs/UserGuide.md mkdocs/SystemGuide.md mkdocs/Applications.md \
+                mkdocs/Catalog.md mkdocs/Hardware.md mkdocs/ReadMe.md
 	mkdir -p mkdocs/UserGuide/Graphics mkdocs/SystemGuide/Graphics
-	cp Introduction.gfm      mkdocs/Introduction.md
-	cp UserGuide.gfm         mkdocs/UserGuide.md
-	cp SystemGuide.gfm       mkdocs/SystemGuide.md
-	cp Applications.gfm      mkdocs/Applications.md
-	cp Catalog.gfm           mkdocs/Catalog.md
-	cp Hardware.gfm          mkdocs/Hardware.md
-	cp ReadMe.gfm            mkdocs/README.md
+	mv mkdocs/ReadMe.md mkdocs/README.md
 	cp Graphics/*.svg        mkdocs/UserGuide/Graphics
 	cp Graphics/*.svg        mkdocs/SystemGuide/Graphics


### PR DESCRIPTION
Now when online docs are build, `gpp` is called with a `-DGFM` argument, which `Basic.h` uses to create the proper links.
