### PR TITLE
Make sure the images in *.def files are build as dependencies

### DIFF
--- a/Source/Images/Makefile
+++ b/Source/Images/Makefile
@@ -41,6 +41,11 @@ TEMP := $(addprefix hd512_,$(TEMP)) $(addprefix hd1k_,$(TEMP))
 TEMP := $(TEMP:.def=.img)
 OBJECTS += $(TEMP)
 
+TEMP = $(shell grep -vEh "^\#" *.def)
+TEMP := $(addprefix hd512_,$(TEMP)) $(addprefix hd1k_,$(TEMP))
+TEMP := $(addsuffix .img,$(TEMP))
+OBJECTS += $(TEMP)
+
 
 OTHERS = blank144 blankhd512 blankhd1k *.cat
 


### PR DESCRIPTION
Added some code to make the content of the *.def files to build a custom image appear as dependencies to be build.
