### PR TITLE
HBIOS/TMS Driver: updated to probe and detect VDP chip type and amount of VRAM available

### DIFF
--- a/Source/HBIOS/tms.asm
+++ b/Source/HBIOS/tms.asm
@@ -882,41 +882,41 @@ TMS_VRMPRB:
 	XOR	A			; SET RETURN VALUE FOR 64K
 	INC	A
 	EX	AF,AF'
-	LD      A,4
+	LD	A,4
 	; USE 16 BIT I/O ADDRESS FOR EZ80 COMPATIBILITY 
 	; (AVOID NEED FOR EZ80_IO MACRO)
 	LD	BC, (IO_SEGMENT<<8)+TMS_CMDREG
-	OUT     (C),A
+	OUT	(C),A
 	CALL	DLY64			; DELAY
-	LD      A,$8E
-	OUT     (C),A			; R#14 = 4 -> A16 = 1, A15..A14 = 0
+	LD	A,$8E
+	OUT	(C),A			; R#14 = 4 -> A16 = 1, A15..A14 = 0
 	CALL	DLY64			; DELAY
-	XOR     A
-	OUT     (C),A			; A7..A0 = 0
+	XOR	A
+	OUT	(C),A			; A7..A0 = 0
 	CALL	DLY64			; DELAY
-	OR      $40
-	OUT     (C),A			; SET WR, A13..A8 = 0
+	OR	$40
+	OUT	(C),A			; SET WR, A13..A8 = 0
 	CALL	DLY64			; DELAY
-	LD      A,$76
+	LD	A,$76
 	CALL	DLY64			; DELAY
 	LD	C, TMS_DATREG
-	OUT     (C),A			; SET VRAM $10000 = $76
+	OUT	(C),A			; SET VRAM $10000 = $76
 	CALL	DLY64			; DELAY
-	XOR     A
+	XOR	A
 	LD	C, TMS_CMDREG
-	OUT     (C),A			; A7..A0 = 0
+	OUT	(C),A			; A7..A0 = 0
 	CALL	DLY64			; DELAY
 
-	OUT     (C),A			; SET RD, A13..A8 = 0
+	OUT	(C),A			; SET RD, A13..A8 = 0
 	CALL	DLY64			; DELAY
 	LD	C, TMS_DATREG
-	IN      A,(C)			; A = VRAM $10000
+	IN	A,(C)			; A = VRAM $10000
 	CALL	DLY64			; DELAY
-	CP      $76
-	JR      Z,VRAMSIZE_128K		; IF ITS $76, WE HAVE AT LEAST 128K
+	CP	$76
+	JR	Z,VRAMSIZE_128K		; IF ITS $76, WE HAVE AT LEAST 128K
 
 	; OTHERWISE ITS ONLY 64K
-	JR      VRAMSIZE_DONE
+	JR	VRAMSIZE_DONE
 
 VRAMSIZE_128K:
 	; WE HAVE AT LEAST 128K
@@ -932,34 +932,34 @@ VRAMSIZE_128K:
 	OUT	(C), A			; R#45 = $40 (MXC=1, MXD,MXS,DIY,DIX,EQ,MAJ=0)
 	CALL	DLY64			; DELAY
 
-	LD      A,1
-	OUT     (C),A
+	LD	A,1
+	OUT	(C),A
 	CALL	DLY64			; DELAY
-	LD      A,$8E
-	OUT     (C),A			; R#14 = 4 -> A16 = 0, A15..A14 = 1
+	LD	A,$8E
+	OUT	(C),A			; R#14 = 4 -> A16 = 0, A15..A14 = 1
 	CALL	DLY64			; DELAY
-	XOR     A
-	OUT     (C),A			; A7..A0 = 0
+	XOR	A
+	OUT	(C),A			; A7..A0 = 0
 	CALL	DLY64			; DELAY
-	OR      $40
-	OUT     (C),A			; SET WR, A13..A8 = 0
+	OR	$40
+	OUT	(C),A			; SET WR, A13..A8 = 0
 	CALL	DLY64			; DELAY
-	LD      A,$5A
+	LD	A,$5A
 	CALL	DLY64			; DELAY
 	LD	C, TMS_DATREG
-	OUT     (C),A			; SET VRAM $14000 = $76
+	OUT	(C),A			; SET VRAM $14000 = $76
 	CALL	DLY64			; DELAY
-	XOR     A
+	XOR	A
 	LD	C, TMS_CMDREG
-	OUT     (C),A			; A7..A0 = 0
+	OUT	(C),A			; A7..A0 = 0
 	CALL	DLY64			; DELAY
-	OUT     (C),A			; SET RD, A13..A8 = 0
+	OUT	(C),A			; SET RD, A13..A8 = 0
 	CALL	DLY64			; DELAY
 	LD	C, TMS_DATREG
-	IN      A,(C)			; A = VRAM $14000
+	IN	A,(C)			; A = VRAM $14000
 	CALL	DLY64			; DELAY
-	CP      $5A
-	JR      NZ,VRAMSIZE_DONE	; IF ITS $5A, WE HAVE EXAPANSION VRAM
+	CP	$5A
+	JR	NZ,VRAMSIZE_DONE	; IF ITS $5A, WE HAVE EXAPANSION VRAM
 
 	EX	AF, AF'
 	INC	A			; SET RETURN VALUE TO 2 FOR 192K
@@ -974,11 +974,11 @@ VRAMSIZE_DONE:
 	OUT	(C), A		;	 R#45 = $00 (MXC=0, MXD,MXS,DIY,DIX,EQ,MAJ=0)
 	CALL	DLY64			; DELAY
 
-	XOR     A
-	OUT     (C),A
+	XOR	A
+	OUT	(C),A
 	CALL	DLY64			; DELAY
-	LD      A,$8E
-	OUT     (C),A			; R#14 = 0 -> A16..A14 = 0
+	LD	A,$8E
+	OUT	(C),A			; R#14 = 0 -> A16..A14 = 0
 
 	EX	AF, AF'
 	RET


### PR DESCRIPTION
Enhancement for your consideration, to the TMS driver.  Happy to discuss if you have feedback/concerns with the approach.

The tms.asm driver currently supports, via configuration options, logic to drive 3 different chip types:

1. TMS9918 (original)
2. Yamaha V9938
3. Yamaha V9958

The Yamaha chips, are for the most part, backwards compatible with the TMS chip - although the tms chip does not have an 80 column text mode.

I have a couple of commits here, that add to the TMS_INIT function to detect and report the type of chip actually installed.  **It does not change operation of driver based on this detection.**

The V99x8 chips have registers to report their ids - but the tms chip does not contain such registers.  But using a specific technique, it is possible to test for the older TMS chip. (The detection algorithm is explained in routine at `TMS_IS9918:`

New sub-routines added:
`TMS_IS9918`: Detects if a original TMS9918 is present
`TMS_GETTYP`: If `TMS_IS9918` fails, attempt to test for V99x8 chips.
`TMS_VRMPRB`: Test for 64k, 128k or 192k of vram available for v99x8 chip only*

* assume TMS has maximum of 16k available

`TMS_PROBE`: is unchanged - it detect for VDP type present.
config option `TMS80COLS` is unchanged, and should still cause the driver to assume the installed chip can support 80 columns.  It appears this forces the driver to assume it does have a V99x8 chip, even if its not present - (i think)

Additional:
Updated the boot report to indicate frequency.  The V99x8 can be configured, via their registers, to operate at 50hz or 60hz.  The  J.B. Langston's TMS9918 can only operate at 60hz (ntsc) .  Not aware of any  TMS9928 module for RCBus/RC2014 systems, that run at 50hz.

Testing:
I have tested with J.B. Langston's TMS9918A module, and my various V99x8 modules/configurations.  

Not Tested/Future possibilities:

Not tested with the TMSEMU3 fpga based emulator -- not sure, but i understand this module emulates the TMS9918 chip, but also has support for 80 columns.  

Maybe a future enhancement would be to auto detect this module - and then we can auto enable 80 columns - reducing need for the config option.  Not sure who best to discuss this with -- With your permission @wwarthen , I can post a link to this PR on retro-comp, in case anyone has insights.


