### PR TITLE
fix: zxcc 

### DIFF
--- a/Tools/unix/zxcc/zxcbdos.c
+++ b/Tools/unix/zxcc/zxcbdos.c
@@ -139,9 +139,9 @@ void cout(byte c)
 
 int cstat()
 {
-	int i;
+	int i = 0;
 
-	ioctl(STDIN_FILENO, FIONREAD, &i);
+	if (ioctl(STDIN_FILENO, FIONREAD, &i) < 0) return 0;
 	if (i > 0) return 0xFF;
 	return 0;
 }


### PR DESCRIPTION
Hey, found a bug in Tools/unix/zxcc/zxcbdos.c - when running in a pipeline or docker non interactive without stdin it kept failing to run properly. This fixed the problem.
