### PR TITLE
Fix building zxcc with modern GCC

### DIFF
--- a/Tools/unix/zxcc/z80.h
+++ b/Tools/unix/zxcc/z80.h
@@ -37,8 +37,8 @@
 #define Z80_save  5
 #define Z80_log   6
 
-unsigned int in();
-unsigned int out();
+unsigned int in(int, int, int);
+unsigned int out(int, int, int, int);
 //int interrupt();
 int snapload();
 void snapsave();

--- a/Tools/unix/zxcc/zxbdos.h
+++ b/Tools/unix/zxcc/zxbdos.h
@@ -45,5 +45,7 @@ gsx_byte gsxrd(gsx_word addr);
 void gsxwr(gsx_word addr, gsx_byte value);
 #endif
 
-void cpmbdos();
-void cpmbios();
+void cpmbdos(byte* a, byte* b, byte* c, byte* d, byte* e, byte* f,
+			 byte* h, byte* l, word* pc, word* ix, word* iy);
+void cpmbios(byte* a, byte* b, byte* c, byte* d, byte* e, byte* f,
+	byte* h, byte* l, word* pc, word* ix, word* iy);

--- a/Tools/unix/zxcc/zxcc.c
+++ b/Tools/unix/zxcc/zxcc.c
@@ -227,8 +227,8 @@ void load_comfile(void)
 	DBGMSGV("Loaded %d bytes from %s\n", com_len, fname);
 }
 
-unsigned int in() { return 0; }
-unsigned int out() { return 0; }
+unsigned int in(int, int, int) { return 0; }
+unsigned int out(int, int, int, int) { return 0; }
 
 /*
  * xltname: Convert a unix filepath into a CP/M compatible drive:name form.


### PR DESCRIPTION
GCC 15 defaults to C23. C23 assumes that a function declaration without an argument list has no arguments, rather than an unknown number of arguments, so it fails to build.

This PR adds argument lists to function declarations missing them.

No use of LLMs.