### PR TITLE
fix: uz80as errors on out-of-range JR displacement instead of silently ignoring the error

### DIFF
--- a/Tools/unix/uz80as/z80.c
+++ b/Tools/unix/uz80as/z80.c
@@ -289,7 +289,19 @@ static int gen_z80(int *eb, char p, const int *vs, int i, int savepc)
 	switch (p) {
 	case 'f': b |= (vs[i] << 4); break;
 	case 'g': b |= (vs[i] << 6); break;
-	case 'i': b = (vs[i] - savepc - 2); break;
+	case 'i': if (s_pass > 0 && vs[i] > savepc && (vs[i] - savepc - 2) > 127) {
+			  eprint(_("relative jump out of bounds from (%d) to (%d)\n"),
+				savepc, vs[i]);
+			  eprcol(s_pline, s_pline_ep);
+			  newerr();
+		} else if (s_pass > 0 && vs[i] < savepc && (vs[i] - savepc - 2) < -128) {
+			  eprint(_("relative jump out of bounds from (%d) to (%d)\n"),
+				savepc, vs[i]);
+			  eprcol(s_pline, s_pline_ep);
+			  newerr();
+		}
+		b = (vs[i] - savepc - 2);
+		break;
 	case 'j': if (s_pass > 0 && (vs[i] & ~56) != 0) {
 			  eprint(_("invalid RST argument (%d)\n"),
 				vs[i]);


### PR DESCRIPTION
This one has bitten me 4 times in total, fixing it so other people don't fall in the same trap.