### PR TITLE
fix short-read padding

### DIFF
--- a/Tools/unix/zxcc/cpmredir.c
+++ b/Tools/unix/zxcc/cpmredir.c
@@ -292,7 +292,7 @@ cpm_word fcb_read(cpm_byte* fcb, cpm_byte* dma)
 	}
 
 	/* if not multiple of 128 bytes, pad sector with 0x1A */
-	for (n = rv; n < rd_len; n++) dma[n] = 0x1A;
+	for (n = rv; n < redir_rec_len; n++) dma[n] = 0x1A;
 
 	/* Less was read in than asked for. Report the number of 128-byte
 	 * records that _were_ read in.
@@ -514,7 +514,7 @@ cpm_word fcb_randrd(cpm_byte* fcb, cpm_byte* dma)
 	rd_len = ((rv + 127) / 128) * 128;
 
 	/* PMO: pad partial sector to 128 bytes, even if EOF reached in multi sector read */
-	for (n = rv; n < rd_len; n++) dma[n] = 0x1A;	/* pad last read to 128 boundary with 0x1A*/
+	for (n = rv; n < redir_rec_len; n++) dma[n] = 0x1A;	/* pad last read to 128 boundary with 0x1A*/
 
 	if (rd_len < redir_rec_len)  /* eof */
 	{


### PR DESCRIPTION
Wayne,

Yeah something completely different now.

I was trying to get Hitech-C working with zxcc in makefiles. 
Yeah I know there are better c compilers available on linux and windows. 
But I wanted code generated by the real compilers of the time.
And what I found was that it was not working at all.
After the CPP step I always had errors like 

55    "illegal character (00)"

But the cpp output never contained the 00 char on disk.
So I went investigating after hours of dumping data adding debug code I found out that the read of what CPP created on disk should have been padded by Ctrl-z 0x1A and it was not.
I found the difference when I ran the cpp on real hardware and saw the difference in the file.

So I had a lead turns out there is a bug in the fill algorithm implemented in zxcc.
It does not fill the buffer until the end it just stops at the last byte read.
So taken hours of my time and this is the fix.... two lines of code.
And now hitech can be used in Makefiles on linux.
Here an example of a makefile.

OBJECTS = s.com
OTHERS = ENVIRON
DEST = ../../../Binary/Apps
TOOLS = ../../../Tools

HITECHDIR = $(shell cd ../../Images/d_hitechc/u0 && pwd)/
export BINDIR80 = $(HITECHDIR)
export LIBDIR80 = $(HITECHDIR)
export INCDIR80 = $(HITECHDIR)

include $(TOOLS)/Makefile.inc

%.com: %.c
        @printf 'HITECH=A:\r\nTMP=B:\r\n\x1a' > ENVIRON
        @rm -f $@
        $(ZXCC) C --V --N $<


The ENVIRON is specially needed by Hitech-C to find the compiler I have that on my base system also.

Hope this will help other people use the compiler.

Thanks. Willy.