### PR TITLE
fix: i2cscan PCF_WAIT_FOR_BB inverted busy/free polarity

### DIFF
--- a/Source/Apps/Test/I2C/i2cscan.asm
+++ b/Source/Apps/Test/I2C/i2cscan.asm
@@ -341,7 +341,10 @@ PCF_WAIT_FOR_BB:
 PCF_WFBB0:
 	IN     A,(PCF_RS1)
         AND    PCF_BB
-        RET    Z		; BUS IS FREE RETURN ZERO
+        JR     Z,PCF_WFBBCONT	; BB=0 MEANS BUSY
+	CP	A
+	RET
+PCF_WFBBCONT:
         DEC    HL
         LD     A,H
         OR     L


### PR DESCRIPTION
Small fix in an app programs to scan the i2c bus. should make it much faster to scan the bus.
Speed up from about 0.5 seconds for 16 scan addresses to about 50ms instead.
Effectively the condition was wrong it was nvested.