### PR TITLE
Add SAA1099 reset routine

### DIFF
--- a/Source/HBIOS/saa.asm
+++ b/Source/HBIOS/saa.asm
@@ -1,17 +1,17 @@
 ;======================================================================
 ;
-;	SAA1906A SOUND CHIP DRIVER
+;	SAA1099 SOUND CHIP DRIVER
 ;
 ;======================================================================
 ;
 ; THIS IS CURRENTLY JUST A DUMMY DRIVER TO IMPLEMENT A SIMPLE
-; HARDWARE RESET AT BOOT FOR THE SAA1906A.
+; HARDWARE RESET AT BOOT FOR THE SAA1099.
 ;
 ; THE DRIVER IS NOT REGISTERED AND THERE IS NO FUNCTION DISPATCHING.
 ;
 	DEVECHO	"SAA: IO="
 	DEVECHO SAABASE
-	DEVECHO	" HZ\n"
+	DEVECHO	"\n"
 ;
 ;======================================================================
 ;
@@ -76,10 +76,18 @@ SAA_INIT:
 ;======================================================================
 ;
 SAA_RESET:
-	;
-	; ADD HARDWARE RESET HERE...
-	;
-	XOR	A			; SIGNAL SUCCESS
+
+	LD A,$20		;CLEAR ALL 32 REGISTERS
+
+SAA_RESET_LP:
+	LD BC,SAA_ADR	;BC=ADDR PORT ($01xx)
+	DEC A
+	OUT (C),A
+	DEC B			;BC=DATA PORT ($00xx)
+	OUT (C),B
+	AND A
+	JR NZ,SAA_RESET_LP
+;	XOR	A			; SIGNAL SUCCESS
 	RET				; DONE
 ;
 ;--------------------------------------------------------------------------------------------------

--- a/Source/HBIOS/sctim.asm
+++ b/Source/HBIOS/sctim.asm
@@ -94,7 +94,7 @@ SCTIM_INIT1:
 	; ENABLE THE TIMER
 	OR	$FF			; $FF TO ACCUM
 	OUT	(SCTIMIO),A		; ENABLE INTS
-	XOR				; SIGNAL SUCCESS
+	XOR	A			; SIGNAL SUCCESS
 	RET				; DONE
 ;
 ;==================================================================================================


### PR DESCRIPTION
- add reset routine to the new SAA driver 
- change 'XOR' to 'XOR A' in sctim.asm which was preventing assembly with  uz80as